### PR TITLE
Allow excluding certain source files from mapping

### DIFF
--- a/lib/crystalball/map_generator.rb
+++ b/lib/crystalball/map_generator.rb
@@ -12,8 +12,8 @@ module Crystalball
       # Registers Crystalball handlers to generate execution map during specs execution
       #
       # @param [Proc] block to configure MapGenerator and Register strategies
-      def start!(&block)
-        generator = new(&block)
+      def start!(exclude_sources: [], &block)
+        generator = new(exclude_sources: exclude_sources, &block)
 
         ::RSpec.configure do |c|
           c.before(:suite) { generator.start! }
@@ -25,8 +25,8 @@ module Crystalball
       end
     end
 
-    def initialize
-      @configuration = Configuration.new
+    def initialize(exclude_sources: [])
+      @configuration = Configuration.new(exclude_sources: exclude_sources)
       @configuration.commit = repo.gcommit('HEAD') if repo
       yield @configuration if block_given?
     end

--- a/lib/crystalball/map_generator/configuration.rb
+++ b/lib/crystalball/map_generator/configuration.rb
@@ -12,8 +12,10 @@ module Crystalball
       attr_accessor :commit, :version, :compact_map
 
       attr_reader :strategies
+      attr_reader :exclude_sources
 
-      def initialize
+      def initialize(exclude_sources: [])
+        @exclude_sources = exclude_sources
         @strategies = StrategiesCollection.new
         @compact_map = true
       end
@@ -50,6 +52,7 @@ module Crystalball
       #
       # @param [Crystalball::MapGenerator::BaseStrategy] strategy
       def register(strategy)
+        strategy.exclude_sources = exclude_sources
         @strategies.push strategy
         strategy.after_register
       end

--- a/lib/crystalball/map_generator/coverage_strategy.rb
+++ b/lib/crystalball/map_generator/coverage_strategy.rb
@@ -11,9 +11,15 @@ module Crystalball
       include BaseStrategy
 
       attr_reader :execution_detector
+      attr_reader :exclude_sources
 
       def initialize(execution_detector = ExecutionDetector.new)
         @execution_detector = execution_detector
+      end
+
+      def exclude_sources=(value)
+        @exclude_sources = value
+        @execution_detector.exclude_sources = value
       end
 
       def after_register

--- a/lib/crystalball/map_generator/helpers/path_filter.rb
+++ b/lib/crystalball/map_generator/helpers/path_filter.rb
@@ -6,6 +6,11 @@ module Crystalball
       # Helper module to filter file paths
       module PathFilter
         attr_reader :root_path
+        attr_writer :exclude_sources
+
+        def exclude_sources
+          @exclude_sources || []
+        end
 
         # @param [String] root_path - absolute path to root folder of repository
         def initialize(root_path = Dir.pwd)
@@ -18,6 +23,8 @@ module Crystalball
           paths
             .select { |file_name| file_name.start_with?(root_path) }
             .map { |file_name| file_name.sub("#{root_path}/", '') }
+            .reject { |file_name| exclude_sources.any? do |pattern| pattern.match?(file_name) end }
+
         end
       end
     end

--- a/spec/map_generator/configuration_spec.rb
+++ b/spec/map_generator/configuration_spec.rb
@@ -30,7 +30,7 @@ describe Crystalball::MapGenerator::Configuration do
   end
 
   describe '#register' do
-    let(:strategy) { double(after_register: true) }
+    let(:strategy) { double(after_register: true, 'exclude_sources=' => []) }
     it 'adds a strategy to collection' do
       expect do
         subject.register strategy


### PR DESCRIPTION
**THIS IS STILL MAINLY A DRAFT**

A proposal on filtering source files as per suggested on the example in issue #118.

As I suggested there, I think it would be more granular and cleaner to implement if this exclusion was at each strategy level rather than at the `MapGenerator` level. Also each strategy could be dealt with one at a time, making review easier.

I'll leave comments on what could be simplified with this approach and what parts are ugly and will be refactored once we decide further course of action.

Since this is just a draft I haven't made any test already; I tested it locally (only on coverage strategy) by vendoring the gem and testing on some code that actually called also vendored `rspec` gem. Test will be my starting point for any further advancement.

I'll expect some type of response before continuing development.